### PR TITLE
Remove class constraint, allowing struct to be used, as well.

### DIFF
--- a/src/Microsoft.Extensions.Configuration.ImmutableBinder/ImmutableConfigurationBinder.cs
+++ b/src/Microsoft.Extensions.Configuration.ImmutableBinder/ImmutableConfigurationBinder.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Extensions.Configuration.ImmutableBinder
         ///     If binding of the <paramref name="configuration"/> failed due to any reason.
         /// </exception>
         public static T ImmutableBind<T>(this IConfiguration configuration)
-            where T : class
         {
             if (configuration == null)
             {


### PR DESCRIPTION
With readonly struct now allowing more compiler enforced immutability, it is handy to have a way to use them for configuration objects.